### PR TITLE
Dependency fix when depending on worlds and systems

### DIFF
--- a/Module/main.js
+++ b/Module/main.js
@@ -199,19 +199,19 @@ class BugReportForm extends FormApplication {
    */
   get dependencies() {
     return this.module.data.dependencies?.map((dependency) => {
-      let package = game.modules.get(dependency.name);
-      if (package === undefined){
+      let plugin = game.modules.get(dependency.name);
+      if (plugin === undefined){
         if (dependency.name === game.system.data.name) {
-          package = game.system;
+          plugin = game.system;
         } else if (dependency.name === game.world.data.name) {
-          package = game.world;
+          plugin = game.world;
         }
       }
       let upToDate;
       // get remote manifest
-      let remote = this.checkVer(package);
+      let remote = this.checkVer(plugin);
       // determine status
-      if (!isNewerVersion(remote.manifest?.version, package.data.version)) {
+      if (!isNewerVersion(remote.manifest?.version, plugin.data.version)) {
         // we are up to date
         upToDate = true;
       } else {
@@ -220,11 +220,11 @@ class BugReportForm extends FormApplication {
       }
       // assemble return
       return {
-        name: package.data.title,
-        // If package is a module, then check if it's active
+        name: plugin.data.title,
+        // If plugin is a module, then check if it's active
         // otherwise it's a system/world that is always active.
-        active: package.type === "module" ? package.active : true,
-        version: package.data.version,
+        active: plugin.type === "module" ? plugin.active : true,
+        version: plugin.data.version,
         upToDate
       }
     })

--- a/Module/main.js
+++ b/Module/main.js
@@ -199,12 +199,19 @@ class BugReportForm extends FormApplication {
    */
   get dependencies() {
     return this.module.data.dependencies?.map((dependency) => {
-      const mod = game.modules.get(dependency.name);
+      let package = game.modules.get(dependency.name);
+      if (package === undefined){
+        if (dependency.name === game.system.data.name) {
+          package = game.system;
+        } else if (dependency.name === game.world.data.name) {
+          package = game.world;
+        }
+      }
       let upToDate;
       // get remote manifest
-      let remote = this.checkVer(mod);
+      let remote = this.checkVer(package);
       // determine status
-      if (!isNewerVersion(remote.manifest?.version, mod.data.version)) {
+      if (!isNewerVersion(remote.manifest?.version, package.data.version)) {
         // we are up to date
         upToDate = true;
       } else {
@@ -213,9 +220,11 @@ class BugReportForm extends FormApplication {
       }
       // assemble return
       return {
-        name: mod.data.title,
-        active: mod.active,
-        version: mod.data.version,
+        name: package.data.title,
+        // If package is a module, then check if it's active
+        // otherwise it's a system/world that is always active.
+        active: package.type === "module" ? package.active : true,
+        version: package.data.version,
         upToDate
       }
     })

--- a/Module/main.js
+++ b/Module/main.js
@@ -199,14 +199,19 @@ class BugReportForm extends FormApplication {
    */
   get dependencies() {
     return this.module.data.dependencies?.map((dependency) => {
-      let plugin = game.modules.get(dependency.name);
-      if (plugin === undefined){
-        if (dependency.name === game.system.data.name) {
+      let plugin;
+
+      switch (dependency.type) {
+        case "module":
+          plugin = game.modules.get(dependency.name);
+          break;
+        case "system":
           plugin = game.system;
-        } else if (dependency.name === game.world.data.name) {
+          break;
+        case "world":
           plugin = game.world;
-        }
       }
+
       let upToDate;
       // get remote manifest
       let remote = this.checkVer(plugin);


### PR DESCRIPTION
Closes #96 where module fails to load with non-module dependencies. This commit adds some safeguards to catch system and world dependencies.