### PR TITLE
v10 Basic Support

### DIFF
--- a/Module/main.js
+++ b/Module/main.js
@@ -194,7 +194,7 @@ class BugReportForm extends FormApplication {
      */
     get conflicts() {
         // Migrate Conflicts to v10 Format
-        let v9Conflicts = foundry.utils.mergeObject((this.module.data.conflicts ?? []), (this.module.flags.conflicts ?? []), {inplace: false})?.map((conflict) => {
+        let v9Conflicts = foundry.utils.mergeObject((this.module?.data?.conflicts ?? []), (this.module?.flags?.conflicts ?? []), {inplace: false})?.map((conflict) => {
             return {
                 id: conflict?.id ?? conflict?.name,
                 type: conflict.type,
@@ -208,7 +208,7 @@ class BugReportForm extends FormApplication {
             }
         });
 
-        return foundry.utils.mergeObject(v9Conflicts, (this.module.relationships.conflicts ?? []))?.map((conflict) => {
+        return foundry.utils.mergeObject(v9Conflicts, (this.module?.relationships?.conflicts ?? []))?.map((conflict) => {
             const mod = game.modules.get(conflict.id);
             let conflictingVersion = false;
             let versionChecks = false;

--- a/Module/main.js
+++ b/Module/main.js
@@ -208,27 +208,29 @@ class BugReportForm extends FormApplication {
             }
         });
 
-        return foundry.utils.mergeObject(v9Conflicts, (this.module?.relationships?.conflicts ?? []))?.map((conflict) => {
+        return foundry.utils.mergeObject(v9Conflicts, Array.from(this.module?.relationships?.conflicts?? [])).filter(conflict => {
+            const mod = game.modules.get(conflict.id);
+            return (mod ?? false) && (mod?.active ?? false);
+        })?.map((conflict) => {
             const mod = game.modules.get(conflict.id);
             let conflictingVersion = false;
             let versionChecks = false;
 
             // Check if utilizing option versionMin / versionMax fields
             if ((conflict.compatibility.minimum ?? false) && (conflict.compatibility.maximum ?? false)) {
-                versionChecks = true;
+                 versionChecks = true;
                 // find if current module version is within the versionMin and versionMax fields
                 if (
-                    isNewerVersion(mod.version ?? mod.data.version, conflict.compatibility.minimum) &&
-                    !isNewerVersion(mod.version ?? mod.data.version, conflict.compatibility.maximum)
-                ) {
+                    isNewerVersion(mod.version ?? (mod?.data?.version ?? '0.0.0'), conflict.compatibility.minimum) &&
+                    !isNewerVersion(mod.version ?? (mod?.data?.version ?? '0.0.0'), conflict.compatibility.maximum)
+                 ) {
                     conflictingVersion = true;
-                }
+                 }
             }
-
             return {
-                name: mod?.title ?? mod.data.title,
+                name: mod?.title ?? (mod?.data?.title ?? ''),
                 active: mod.active,
-                version: mod.version ?? mod.data.version,
+                version: mod.version ?? (mod?.data?.version ?? ''),
                 conflictingVersion,
                 versionChecks,
             };

--- a/Module/module.json
+++ b/Module/module.json
@@ -69,29 +69,7 @@
     "readme": "https://github.com/League-of-Foundry-Developers/bug-reporter/blob/master/README.md",
     "bugs": "https://github.com/League-of-Foundry-Developers/bug-reporter/issues",
     "allowBugReporter": true,
-    "conflicts": [
-        {
-            "name": "lib-changelogs",
-            "description": "Changelogs & Conflicts provides similar features. These modules will work together just fine, this is more of a sample conflict then an actual conflict.",
-            "versionMin": "0.0.6"
-        },
-        {
-            "name": "tidy-ui_game-settings",
-            "description": "MM+ Provides many of the features found in TidyUI Game settings such as the ability to Export/Import Module Lists and Accordian Style Settings for a clearer look. It is suggested to use one or the other modules, not both at the same time. If you choose to run both at the same time, MMP will attempt to provide compatiblity with TidyUI by disabling itself on the Module Settings Tab."
-        }
-    ],
     "flags": {
-      "allowBugReporter": true,
-      "conflicts": [
-          {
-              "name": "lib-changelogs",
-              "description": "Changelogs & Conflicts provides similar features. These modules will work together just fine, this is more of a sample conflict then an actual conflict.",
-              "versionMin": "0.0.6"
-          },
-          {
-              "name": "tidy-ui_game-settings",
-              "description": "MM+ Provides many of the features found in TidyUI Game settings such as the ability to Export/Import Module Lists and Accordian Style Settings for a clearer look. It is suggested to use one or the other modules, not both at the same time. If you choose to run both at the same time, MMP will attempt to provide compatiblity with TidyUI by disabling itself on the Module Settings Tab."
-          }
-      ]
+      "allowBugReporter": true
     }
 }

--- a/Module/module.json
+++ b/Module/module.json
@@ -1,10 +1,16 @@
 {
+    "id": "bug-reporter",
     "name": "bug-reporter",
     "title": "🐛 Bug Reporter",
     "description": "Adds a utility in game to report bugs without having to leave Foundry.",
     "version": "Replaced in releases",
     "minimumCoreVersion": "9",
     "compatibleCoreVersion": "9",
+    "compatibility": {
+      "minimum": 10,
+      "verified": 10,
+      "maximum": 10
+    },
     "author": "Ethck",
     "authors": [
         {

--- a/Module/module.json
+++ b/Module/module.json
@@ -69,7 +69,29 @@
     "readme": "https://github.com/League-of-Foundry-Developers/bug-reporter/blob/master/README.md",
     "bugs": "https://github.com/League-of-Foundry-Developers/bug-reporter/issues",
     "allowBugReporter": true,
+    "conflicts": [
+        {
+            "name": "lib-changelogs",
+            "description": "Changelogs & Conflicts provides similar features. These modules will work together just fine, this is more of a sample conflict then an actual conflict.",
+            "versionMin": "0.0.6"
+        },
+        {
+            "name": "tidy-ui_game-settings",
+            "description": "MM+ Provides many of the features found in TidyUI Game settings such as the ability to Export/Import Module Lists and Accordian Style Settings for a clearer look. It is suggested to use one or the other modules, not both at the same time. If you choose to run both at the same time, MMP will attempt to provide compatiblity with TidyUI by disabling itself on the Module Settings Tab."
+        }
+    ],
     "flags": {
-      "allowBugReporter": true
+      "allowBugReporter": true,
+      "conflicts": [
+          {
+              "name": "lib-changelogs",
+              "description": "Changelogs & Conflicts provides similar features. These modules will work together just fine, this is more of a sample conflict then an actual conflict.",
+              "versionMin": "0.0.6"
+          },
+          {
+              "name": "tidy-ui_game-settings",
+              "description": "MM+ Provides many of the features found in TidyUI Game settings such as the ability to Export/Import Module Lists and Accordian Style Settings for a clearer look. It is suggested to use one or the other modules, not both at the same time. If you choose to run both at the same time, MMP will attempt to provide compatiblity with TidyUI by disabling itself on the Module Settings Tab."
+          }
+      ]
     }
 }


### PR DESCRIPTION
- Updated generateActiveModuleList to handle v9 and v10 game.modules
- Put logic to migrate v9 conflict schema to v10. Not sure this is used anywhere though
- Changed `Description` from bold to title, Personally think it looks nicer
- Added logic so missing apiDetails doesn't create blank details
- Update Core/System header to handle for v9 and v10